### PR TITLE
feat: enhance EncodableBot structure with new fields

### DIFF
--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -21,8 +21,6 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
 	spawn_blocking(move || {
 		let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-		let config = &state.config;
-
 		let num_bots: i64 = bots::table.count().get_result(conn)?;
 
 		fn encode_bots(bot_list: Vec<Bot>) -> AppResult<Vec<EncodableBot>> {
@@ -50,8 +48,8 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
 		// TODO: top rated, most voted
 		Ok(Json(json!({
 			"num_bots": num_bots,
-			"new_bots": encode_bots( new_bots)?,
-			"just_updated": encode_bots( just_updated)?,
+			"new_bots": encode_bots(new_bots)?,
+			"just_updated": encode_bots(just_updated)?,
 			"popular_categories": popular_categories,
 		})))
 	})

--- a/src/views.rs
+++ b/src/views.rs
@@ -165,14 +165,17 @@ pub struct OwnedBot {
 pub struct EncodableBot {
 	pub id: String,
 	pub name: String,
-	#[serde(with = "rfc3339")]
-	pub updated_at: NaiveDateTime,
-	pub categories: Option<Vec<String>>,
-	#[serde(with = "rfc3339")]
-	pub created_at: NaiveDateTime,
+	pub avatar: Option<String>,
 	pub description: String,
 	pub short_description: String,
 	pub supported_languages: Vec<Option<BotLanguages>>,
+	pub categories: Option<Vec<String>>,
+	pub guild_count: i32,
+	pub status: String,
+	#[serde(with = "rfc3339")]
+	pub updated_at: NaiveDateTime,
+	#[serde(with = "rfc3339")]
+	pub created_at: NaiveDateTime,
 }
 
 impl EncodableBot {
@@ -185,6 +188,9 @@ impl EncodableBot {
 			description,
 			short_description,
 			supported_languages,
+			guild_count,
+			status,
+			avatar,
 			..
 		} = bot;
 
@@ -199,6 +205,9 @@ impl EncodableBot {
 			description,
 			short_description,
 			supported_languages,
+			guild_count,
+			status: status.into(),
+			avatar,
 		}
 	}
 


### PR DESCRIPTION
Add new fields to the EncodableBot struct, including avatar, description, 
short_description, supported_languages, categories, guild_count, and status. 
These changes improve the data representation of bots by providing more 
context and details. Refactor related code in the summary function to 
accommodate the updated structure and clean up unused variables.

fixes #100