### PR TITLE
feat(api): enhance EncodableBot with additional description field

### DIFF
--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -26,7 +26,7 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
 		fn encode_bots(bot_list: Vec<Bot>) -> AppResult<Vec<EncodableBot>> {
 			bot_list
 				.into_iter()
-				.map(|b| Ok(EncodableBot::from_minimal(b)))
+				.map(|b| Ok(EncodableBot::from_minimal_no_desc(b)))
 				.collect()
 		}
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
 pub use self::bot::Bot;
-pub use self::category::Category;
+pub use self::category::{BotCategory, Category};
 pub use self::owners::BotOwner;
 pub use self::review::BotReview;
 pub use self::token::{ApiToken, CreatedApiToken};

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -44,7 +44,7 @@ pub fn service_unavailable() -> BoxedAppError {
 }
 
 pub fn bot_not_found(bot: &str) -> BoxedAppError {
-	let detail = format!("crate `{bot}` does not exist");
+	let detail = format!("bot `{bot}` does not exist");
 	custom(StatusCode::NOT_FOUND, detail)
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -162,11 +162,18 @@ pub struct OwnedBot {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct EncodableBotWithDescription<T> {
+	#[serde(flatten)]
+	pub inner: T,
+	pub description: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct EncodableBot {
 	pub id: String,
 	pub name: String,
 	pub avatar: Option<String>,
-	pub description: String,
+	// pub description: String,
 	pub short_description: String,
 	pub supported_languages: Vec<Option<BotLanguages>>,
 	pub categories: Option<Vec<String>>,
@@ -179,7 +186,7 @@ pub struct EncodableBot {
 }
 
 impl EncodableBot {
-	pub fn from(bot: Bot, categories: Option<&[Category]>) -> Self {
+	pub fn from(bot: Bot, categories: Option<&[Category]>) -> EncodableBotWithDescription<Self> {
 		let Bot {
 			id,
 			name,
@@ -196,23 +203,53 @@ impl EncodableBot {
 
 		let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
 
+		EncodableBotWithDescription::<EncodableBot> {
+			inner: EncodableBot {
+				id,
+				name,
+				updated_at,
+				created_at,
+				categories: category_ids,
+				short_description,
+				supported_languages,
+				guild_count,
+				status: status.into(),
+				avatar,
+			},
+			description,
+		}
+	}
+
+	pub fn from_minimal(bot: Bot) -> EncodableBotWithDescription<Self> {
+		Self::from(bot, None)
+	}
+
+	pub fn from_minimal_no_desc(bot: Bot) -> Self {
+		let Bot {
+			id,
+			name,
+			updated_at,
+			created_at,
+			short_description,
+			supported_languages,
+			guild_count,
+			status,
+			avatar,
+			..
+		} = bot;
+
 		EncodableBot {
 			id,
 			name,
 			updated_at,
 			created_at,
-			categories: category_ids,
-			description,
+			categories: None,
 			short_description,
 			supported_languages,
 			guild_count,
 			status: status.into(),
 			avatar,
 		}
-	}
-
-	pub fn from_minimal(bot: Bot) -> Self {
-		Self::from(bot, None)
 	}
 }
 
@@ -238,7 +275,7 @@ impl From<CreatedApiToken> for EncodableApiTokenWithToken {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GoodBot {
-	pub bot: EncodableBot,
+	pub bot: EncodableBotWithDescription<EncodableBot>,
 	pub warnings: PublishWarnings,
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -173,7 +173,6 @@ pub struct EncodableBot {
 	pub id: String,
 	pub name: String,
 	pub avatar: Option<String>,
-	// pub description: String,
 	pub short_description: String,
 	pub supported_languages: Vec<Option<BotLanguages>>,
 	pub categories: Option<Vec<String>>,
@@ -224,7 +223,7 @@ impl EncodableBot {
 		Self::from(bot, None)
 	}
 
-	pub fn from_minimal_no_desc(bot: Bot) -> Self {
+	pub fn from_with_no_desc(bot: Bot, categories: Vec<String>) -> Self {
 		let Bot {
 			id,
 			name,
@@ -243,7 +242,7 @@ impl EncodableBot {
 			name,
 			updated_at,
 			created_at,
-			categories: None,
+			categories: Some(categories),
 			short_description,
 			supported_languages,
 			guild_count,


### PR DESCRIPTION
Refactor the EncodableBot struct to include a description field 
as part of a new EncodableBotWithDescription wrapper. Update 
methods to reflect these changes, including from_minimal and 
removal of the description from EncodableBot. Modify encoding 
logic in the summary controller to accommodate the new structure. 
This improves the API response by providing more context 
about each bot.