### PR TITLE
feat(docker): improve Dockerfile by caching cargo dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,17 @@ ARG DIESEL_CLI_VERSION=2.2.4
 
 RUN apt-get update \
     && apt-get install -y postgresql \
-    && rm -rf /var/lib/apt/lists/* \
-    && cargo install diesel_cli --version $DIESEL_CLI_VERSION --no-default-features --features postgres
+    && rm -rf /var/lib/apt/lists/*
+
+# Install diesel-cli
+RUN cargo install diesel_cli --version $DIESEL_CLI_VERSION --no-default-features --features postgres
+
+# Cache cargo dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
 
 COPY . .
 


### PR DESCRIPTION
Enhance the Dockerfile by adding a step to cache cargo dependencies, 
which reduces build time. Separate the installation of diesel_cli 
to streamline the process. The changes ensure a more efficient 
build process by including only necessary steps and managing 
dependencies effectively.