### PR TITLE
fix(votes): handle potential None result on total_votes 

### DIFF
--- a/src/controllers/bot/votes.rs
+++ b/src/controllers/bot/votes.rs
@@ -40,7 +40,8 @@ pub async fn votes(app: AppState, Path(bot_id): Path<String>) -> AppResult<Json<
 	let total_votes: i64 = BotVote::belonging_to(&bot)
 		.select(sum_votes)
 		.get_result(&mut conn)
-		.await?;
+		.await
+		.unwrap_or(0);
 
 	Ok(Json(json!({
 		"bot_votes": votes,


### PR DESCRIPTION
Ensure total_votes defaults to 0 if no votes are found. This change 
prevents potential runtime errors when accessing the total votes 
and improves the reliability of the votes endpoint in the bot 
controller.